### PR TITLE
Oracle DB 기반 로그인 인증 시스템 구현

### DIFF
--- a/back/src/main/java/com/moca/app/config/SecurityConfig.java
+++ b/back/src/main/java/com/moca/app/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
 
                 // 5. 요청 경로별 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
-                        // 카카오 로그인 API 경로는 누구나 접근 가능하도록 허용
-                        .requestMatchers("/api/auth/kakao/login").permitAll()
+                        // 인증 관련 API 경로는 누구나 접근 가능하도록 허용
+                        .requestMatchers("/api/auth/**").permitAll()
                         // 다른 모든 요청은 일단 허용 (나중에 필요에 따라 인증 요구하도록 수정)
                         .anyRequest().permitAll()
                 );

--- a/back/src/main/java/com/moca/app/login/AppUser.java
+++ b/back/src/main/java/com/moca/app/login/AppUser.java
@@ -1,0 +1,34 @@
+package com.moca.app.login;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "USERS") // Oracle USERS 테이블과 매핑
+public class AppUser {
+
+    @Id
+    @Column(name = "USER_ID")
+    private String userId; // 사용자 ID (Primary Key)
+
+    @Column(name = "USER_PASSWORD")
+    private String userPassword; // 사용자 비밀번호
+
+    @Column(name = "USER_NAME")
+    private String userName; // 사용자 이름
+
+    @Column(name = "USER_ROLE")
+    private String userRole; // 사용자 역할 (admin, user 등)
+
+    @Builder
+    public AppUser(String userId, String userPassword, String userName, String userRole) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.userName = userName;
+        this.userRole = userRole;
+    }
+}

--- a/back/src/main/java/com/moca/app/login/AppUserRepository.java
+++ b/back/src/main/java/com/moca/app/login/AppUserRepository.java
@@ -1,0 +1,15 @@
+package com.moca.app.login;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AppUserRepository extends JpaRepository<AppUser, String> {
+    // userId와 userPassword로 사용자를 찾는 메서드
+    Optional<AppUser> findByUserIdAndUserPassword(String userId, String userPassword);
+
+    // userId로만 사용자를 찾는 메서드 (중복 체크용)
+    Optional<AppUser> findByUserId(String userId);
+}

--- a/back/src/main/java/com/moca/app/login/JwtTokenProvider.java
+++ b/back/src/main/java/com/moca/app/login/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.moca.app.login;
 
-import com.moca.app.login.User; // User 클래스 import
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -17,21 +16,51 @@ public class JwtTokenProvider {
 
     private long tokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
 
-    // JWT 토큰 생성 메서드를 User 객체를 받도록 수정
+    // 기존 카카오 로그인용 User 객체를 받는 메서드
     public String createToken(User user) {
-        Claims claims = Jwts.claims().setSubject(user.getId().toString()); // JWT payload 에 저장되는 정보단위, 보통 user를 식별하는 값을 넣음
-
-        // 👇 토큰에 담고 싶은 추가 정보(이름, 역할 등)를 claim으로 추가
+        Claims claims = Jwts.claims().setSubject(user.getId().toString());
         claims.put("username", user.getNickname());
-        claims.put("role", "user"); // 역할(role)은 필요에 따라 동적으로 부여 (예: user.getRole())
+        claims.put("role", "user");
 
         Date now = new Date();
         return Jwts.builder()
-                .setClaims(claims) // 정보 저장
-                .setIssuedAt(now) // 토큰 발행 시간 정보
-                .setExpiration(new Date(now.getTime() + tokenValidTime)) // set Expire Time
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenValidTime))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
-}
 
+    // 새로운 일반 로그인용 AppUser 객체를 받는 메서드
+    public String createToken(AppUser appUser) {
+        Claims claims = Jwts.claims().setSubject(appUser.getUserId());
+        claims.put("username", appUser.getUserName());
+        claims.put("role", appUser.getUserRole());
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenValidTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    // JWT 토큰에서 사용자 정보를 추출하는 메서드
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // JWT 토큰의 유효성 검증 메서드
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/back/src/main/java/com/moca/app/service/AuthService.java
+++ b/back/src/main/java/com/moca/app/service/AuthService.java
@@ -1,0 +1,52 @@
+package com.moca.app.service;
+
+import com.moca.app.login.AppUser;
+import com.moca.app.login.AppUserRepository;
+import com.moca.app.login.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AppUserRepository appUserRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 사용자 로그인 처리
+     * @param userId 사용자 ID
+     * @param password 비밀번호
+     * @return JWT 토큰 (로그인 실패시 null)
+     */
+    public String login(String userId, String password) {
+        Optional<AppUser> userOptional = appUserRepository.findByUserIdAndUserPassword(userId, password);
+
+        if (userOptional.isPresent()) {
+            AppUser user = userOptional.get();
+            return jwtTokenProvider.createToken(user);
+        }
+
+        return null; // 로그인 실패
+    }
+
+    /**
+     * 사용자 ID 중복 체크
+     * @param userId 사용자 ID
+     * @return 존재하면 true, 없으면 false
+     */
+    public boolean existsByUserId(String userId) {
+        return appUserRepository.findByUserId(userId).isPresent();
+    }
+
+    /**
+     * JWT 토큰 검증
+     * @param token JWT 토큰
+     * @return 유효하면 true, 무효하면 false
+     */
+    public boolean validateToken(String token) {
+        return jwtTokenProvider.validateToken(token);
+    }
+}

--- a/front/src/contexts/AuthContext.jsx
+++ b/front/src/contexts/AuthContext.jsx
@@ -2,16 +2,11 @@ import { createContext, useState, useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 
-// 1. 임시 사용자 데이터 (나중에 DB에서 가져올 데이터)
-const mockUsers = [
-  { id: 1, username: "admin", password: "password", role: "admin" },
-  { id: 2, username: "user", password: "password", role: "user" },
-];
-
 const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -22,40 +17,71 @@ export const AuthProvider = ({ children }) => {
     }
   }, []);
 
-  const login = (username, password) => {
-    const foundUser = mockUsers.find(
-      (u) => u.username === username && u.password === password
-    );
+  // 일반 로그인 함수 (백엔드 API 호출)
+  const login = async (username, password) => {
+    setLoading(true);
+    try {
+      const response = await fetch('http://localhost:8080/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: username,
+          password: password
+        })
+      });
 
-    if (foundUser) {
-      // 실제 앱에서는 토큰과 같은 민감한 정보는 저장하지 않습니다.
-      const userData = { username: foundUser.username, role: foundUser.role };
-      localStorage.setItem("user", JSON.stringify(userData));
-      console.log(user)
-      setUser(userData);
-      navigate("/home"); // 로그인 성공 시 대시보드(홈) 페이지로 이동
-      return true;
-    } else {
-      alert("아이디 또는 비밀번호가 일치하지 않습니다.");
+      if (response.ok) {
+        const data = await response.json();
+        const token = data.accessToken;
+
+        // JWT 토큰을 localStorage에 저장
+        localStorage.setItem("accessToken", token);
+
+        // 토큰 디코딩하여 사용자 정보 추출
+        const decodedUser = jwtDecode(token);
+        const userData = {
+          username: decodedUser.username,
+          role: decodedUser.role
+        };
+
+        // 사용자 정보 저장 및 상태 업데이트
+        localStorage.setItem("user", JSON.stringify(userData));
+        setUser(userData);
+
+        // 로그인 성공 시 홈 페이지로 이동
+        navigate("/home");
+        return true;
+      } else {
+        const errorData = await response.text();
+        alert(errorData || "아이디 또는 비밀번호가 일치하지 않습니다.");
+        return false;
+      }
+    } catch (error) {
+      console.error("로그인 중 오류 발생:", error);
+      alert("로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
       return false;
+    } finally {
+      setLoading(false);
     }
   };
 
-  // 👇 카카오 로그인 성공 후 호출될 새로운 함수
+  // 카카오 로그인 성공 후 호출될 함수
   const loginWithToken = (token) => {
     try {
-      // 1. 토큰을 localStorage에 저장합니다 (API 요청 시 사용하기 위함).
+      // 토큰을 localStorage에 저장
       localStorage.setItem("accessToken", token);
 
-      // 2. 토큰을 디코딩하여 사용자 정보를 추출합니다.
+      // 토큰을 디코딩하여 사용자 정보를 추출
       const decodedUser = jwtDecode(token);
 
-      // 3. AuthContext의 user 상태를 업데이트하고, localStorage에도 저장합니다.
+      // AuthContext의 user 상태를 업데이트하고, localStorage에도 저장
       const userData = { username: decodedUser.username, role: decodedUser.role };
       localStorage.setItem("user", JSON.stringify(userData));
       setUser(userData);
 
-      // 4. 로그인 성공 후 홈 페이지로 이동합니다.
+      // 로그인 성공 후 홈 페이지로 이동
       navigate("/home");
       alert(`${userData.username}님, 환영합니다!`);
 
@@ -66,12 +92,10 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = () => {
-    // 1. 먼저 메인 페이지로 이동시켜, 현재 페이지(e.g. /admin)의
-    //    ProtectedRoute가 재실행되는 것을 방지합니다.
+    // 메인 페이지로 이동
     navigate("/");
 
-    // 2. 페이지 이동이 완전히 처리될 시간을 벌기 위해,
-    //    상태 변경 로직을 이벤트 루프의 다음 틱으로 보냅니다.
+    // 상태 변경 로직을 이벤트 루프의 다음 틱으로 보냄
     setTimeout(() => {
       localStorage.removeItem("user");
       localStorage.removeItem("accessToken");
@@ -79,8 +103,13 @@ export const AuthProvider = ({ children }) => {
     }, 0);
   };
 
-  // 👇 value에 loginWithToken 함수를 추가
-  const value = { user, login, logout, loginWithToken };
+  const value = {
+    user,
+    login,
+    logout,
+    loginWithToken,
+    loading
+  };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -2,18 +2,28 @@ import { useState } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext.jsx";
-// 1. 카카오 로그인 버튼 컴포넌트를 import 합니다.
 import KakaoLoginButton from '../components/KakaoLoginButton.jsx';
 
-// 2. App.jsx로부터 redirectPath를 props로 받도록 수정합니다.
 const LoginPage = ({ redirectPath }) => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const { login } = useAuth();
+  const { login, loading } = useAuth();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    login(username, password);
+
+    // 입력값 검증
+    if (!username.trim()) {
+      alert("아이디를 입력해주세요.");
+      return;
+    }
+    if (!password.trim()) {
+      alert("비밀번호를 입력해주세요.");
+      return;
+    }
+
+    // 로그인 시도
+    await login(username.trim(), password);
   };
 
   return (
@@ -22,21 +32,24 @@ const LoginPage = ({ redirectPath }) => {
           <h2>로그인</h2>
           <Input
               type="text"
-              placeholder="아이디 (admin 또는 user)"
+              placeholder="아이디를 입력하세요"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
+              disabled={loading}
               required
           />
           <Input
               type="password"
-              placeholder="비밀번호 (password)"
+              placeholder="비밀번호를 입력하세요"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              disabled={loading}
               required
           />
-          <Button type="submit">로그인</Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? "로그인 중..." : "로그인"}
+          </Button>
 
-          {/* 3. '또는' 구분선과 카카오 로그인 버튼을 추가합니다. */}
           <OrSeparator>또는</OrSeparator>
           <KakaoLoginButton redirectPath={redirectPath} />
 
@@ -48,7 +61,6 @@ const LoginPage = ({ redirectPath }) => {
 
 export default LoginPage;
 
-// --- styled-components 코드는 그대로 유지 ---
 const LoginContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -77,6 +89,11 @@ const Input = styled.input`
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 16px;
+
+  &:disabled {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+  }
 `;
 
 const Button = styled.button`
@@ -88,8 +105,14 @@ const Button = styled.button`
   font-size: 16px;
   cursor: pointer;
   transition: background-color 0.2s;
-  &:hover {
+
+  &:hover:not(:disabled) {
     background-color: #4e342e;
+  }
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
   }
 `;
 
@@ -105,7 +128,6 @@ const HomeLink = styled(Link)`
   }
 `;
 
-// 4. '또는' 구분선 스타일을 추가합니다.
 const OrSeparator = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🎯 작업 개요
기존 하드코딩된 mockUsers를 제거하고, Oracle Database의 USERS 테이블을 활용한 실제 로그인 인증 시스템을 구현했습니다.

## ✨ 주요 변경사항

### Backend
- **AppUser 엔티티 추가**: USERS 테이블과 매핑되는 JPA 엔티티
- **AppUserRepository 추가**: 사용자 조회 및 인증을 위한 Repository 인터페이스
- **AuthService 추가**: 일반 로그인 비즈니스 로직 처리 서비스
- **AuthController 수정**: `/api/auth/login` 엔드포인트 추가
- **JwtTokenProvider 확장**: AppUser 객체 지원 메서드 추가
- **SecurityConfig 수정**: 새로운 인증 엔드포인트 허용 설정

### Frontend
- **AuthContext 수정**: mockUsers 제거 및 백엔드 API 호출 로직 구현
- **LoginPage 개선**: 로딩 상태 처리 및 사용자 경험 향상

### Database
- **USERS 테이블 활용**: Oracle DB의 실제 사용자 데이터 조회
- **샘플 데이터 제공**: 테스트용 관리자/일반사용자 계정

## 🔐 인증 시스템 특징
- **이중 로그인 지원**: 일반 로그인 + 카카오 로그인 (기존 유지)
- **JWT 토큰 기반 인증**: 30분 유효시간의 보안 토큰
- **Role 기반 권한 관리**: admin/user 역할 구분

## 🧪 테스트 방법
1. 백엔드 서버 실행: `./gradlew bootRun`
2. 프론트엔드 서버 실행: `npm run dev`
3. 로그인 테스트:
   - `admin` / `password` (관리자)
   - `user` / `password` (일반사용자)
   - `test` / `test123` (테스트사용자)

## 📋 API 엔드포인트
- `POST /api/auth/login`: 일반 사용자 로그인
- `POST /api/auth/validate`: JWT 토큰 검증 (선택적)

## ⚠️ Breaking Changes
- 프론트엔드에서 더 이상 하드코딩된 사용자 데이터를 사용하지 않음
- 모든 로그인 요청이 백엔드 API를 통해 처리됨

## 🔗 관련 이슈
- Oracle Database 연동 요구사항 충족
- 실제 사용자 데이터 기반 인증 시스템 구축 완료