### PR TITLE
Enhance Payment/License page with input formatting and data masking

### DIFF
--- a/front/src/pages/AddPaymentPage.jsx
+++ b/front/src/pages/AddPaymentPage.jsx
@@ -8,10 +8,34 @@ const AddPaymentPage = () => {
     const navigate = useNavigate();
     const { user } = useAuth();
     const [cardCompany, setCardCompany] = useState('');
-    const [cardNumber, setCardNumber] = useState('');
+    const [cardNumber, setCardNumber] = useState(''); // Displayed formatted card number
+    const [rawCardNumber, setRawCardNumber] = useState(''); // Raw 16 digits for backend
     const [expiryDate, setExpiryDate] = useState('');
     const [cvc, setCvc] = useState('');
     const [error, setError] = useState('');
+
+    const handleCardNumberChange = (e) => {
+        const input = e.target.value.replace(/\D/g, ''); // Remove non-digits
+        const formattedInput = input.match(/.{1,4}/g)?.join('-') || '';
+        
+        if (input.length <= 16) {
+            setRawCardNumber(input); // Store raw digits for backend
+            setCardNumber(formattedInput); // Store formatted for display
+        }
+    };
+
+    const handleExpiryDateChange = (e) => {
+        const input = e.target.value.replace(/\D/g, ''); // Remove non-digits
+        let formattedInput = input;
+
+        if (input.length > 2) {
+            formattedInput = input.substring(0, 2) + '/' + input.substring(2, 4);
+        }
+
+        if (input.length <= 4) {
+            setExpiryDate(formattedInput);
+        }
+    };
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -24,8 +48,8 @@ const AddPaymentPage = () => {
 
         const paymentData = {
             cardCompany,
-            cardNumber,
-            cardExpirationDate: expiryDate,
+            cardNumber: rawCardNumber, // Use raw 16 digits for backend
+            cardExpirationDate: expiryDate, // MM/YY format
             isDefault: false,
             cvc
         };
@@ -61,9 +85,9 @@ const AddPaymentPage = () => {
                         id="card-number" 
                         type="text" 
                         value={cardNumber} 
-                        onChange={(e) => setCardNumber(e.target.value)} 
+                        onChange={handleCardNumberChange} 
                         placeholder="- 없이 숫자만 입력"
-                        maxLength="16"
+                        maxLength="19" // 16 digits + 3 hyphens
                         required
                     />
                 </InputGroup>
@@ -73,9 +97,9 @@ const AddPaymentPage = () => {
                         id="expiry-date" 
                         type="text" 
                         value={expiryDate} 
-                        onChange={(e) => setExpiryDate(e.target.value)} 
+                        onChange={handleExpiryDateChange} 
                         placeholder="MM/YY"
-                        maxLength="5"
+                        maxLength="5" // MM/YY
                         required
                     />
                 </InputGroup>

--- a/front/src/pages/MyPage.jsx
+++ b/front/src/pages/MyPage.jsx
@@ -154,7 +154,7 @@ const MyPage = () => {
       </Section>
 
       <MenuSection>
-        <MenuItem onClick={() => navigate('/ocr')}>
+        <MenuItem onClick={() => navigate('/payments-licenses')}>
           <FiCreditCard size={20} />
           <span>운전면허증 정보</span>
           <FiChevronRight />

--- a/front/src/pages/PaymentsAndLicenses.jsx
+++ b/front/src/pages/PaymentsAndLicenses.jsx
@@ -4,6 +4,32 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { getPaymentLicenseInfo, deletePaymentMethod } from '../services/paymentLicenseService';
 
+// Helper function to format card number for display
+const formatCardNumber = (number) => {
+    if (!number) return '';
+    const cleaned = number.replace(/\D/g, ''); // Ensure only digits
+    if (cleaned.length === 16) {
+        return `${cleaned.substring(0, 4)}-****-****-${cleaned.substring(12, 16)}`;
+    }
+    return cleaned.match(/.{1,4}/g)?.join('-') || cleaned; // Fallback for non-16 digit numbers
+};
+
+// Helper function to format license number for display
+const formatLicenseNumber = (number) => {
+    if (!number) return '';
+    const cleaned = number.replace(/\D/g, '');
+    if (cleaned.length === 12) { // Assuming 12 digits for XX-XXXXXXXX-XX
+        return `${cleaned.substring(0, 2)}-${cleaned.substring(2, 10)}-${cleaned.substring(10, 12)}`;
+    }
+    return cleaned; // Return as is if not 10 or 12 digits
+};
+
+// Helper function to format resident registration number for display
+const formatResidentRegistrationNumber = (number) => {
+    if (!number || number.length !== 13) return number; // Ensure 13 digits
+    return `${number.substring(0, 6)}-${number.substring(6, 7)}******`; // Mask last 6 digits
+};
+
 const PaymentsAndLicenses = () => {
     const navigate = useNavigate();
     const { user, authLoading } = useAuth();
@@ -77,7 +103,7 @@ const PaymentsAndLicenses = () => {
                                 <CardIcon>💳</CardIcon>
                                 <CardInfo>
                                     <CardLabel>{p.cardCompany}</CardLabel>
-                                    <CardSubLabel>{p.cardNumber}</CardSubLabel>
+                                    <CardSubLabel>{formatCardNumber(p.cardNumber)}</CardSubLabel>
                                 </CardInfo>
                             </CardContent>
                             <ActionButtons>
@@ -103,8 +129,8 @@ const PaymentsAndLicenses = () => {
                         <CardContent>
                             <CardIcon>🪪</CardIcon>
                             <CardInfo>
-                                <CardLabel>{license.name} ({license.licenseNumber})</CardLabel>
-                                <CardSubLabel>주민번호: {license.residentRegistrationNumber}</CardSubLabel>
+                                <CardLabel>{license.name} ({formatLicenseNumber(license.licenseNumber)})</CardLabel>
+                                <CardSubLabel>주민등록번호: {formatResidentRegistrationNumber(license.residentRegistrationNumber)}</CardSubLabel>
                                 <CardSubLabel>발급일: {new Date(license.issueDate).toLocaleDateString()}</CardSubLabel>
                                 <CardSubLabel>갱신 시작일: {new Date(license.renewalStartDate).toLocaleDateString()}</CardSubLabel>
                                 <CardSubLabel>갱신 종료일: {new Date(license.renewalEndDate).toLocaleDateString()}</CardSubLabel>
@@ -223,6 +249,7 @@ const CardLabel = styled.span`
 const CardSubLabel = styled.span`
     font-size: 14px;
     color: #a1887f;
+    vertical-align: middle;
 `;
 
 const StyledButton = styled.button`


### PR DESCRIPTION
1. UI/UX 개선
마이페이지 네비게이션 변경: 마이페이지 > 운전면허증 정보 클릭 시, 결제 및 면허 관리 페이지로 바로 이동하도록 라우팅 경로를 수정했습니다.

2. 입력 편의성 강화
카드 번호: 숫자 4자리를 입력할 때마다 하이픈(-)이 자동으로 생성됩니다. (예: 1234-5678-1234-5678)

카드 유효기간: 월(MM) 2자리 입력 후 자동으로 슬래시(/)가 추가되어 연도(YY)를 바로 입력할 수 있습니다. (예: 12/28)

운전면허 번호: 기존 형식에 맞춰 자동으로 하이픈(-)이 삽입됩니다. (예: 19-12-123456-12)

3. 보안 강화
카드 번호 마스킹: 카드 번호 16자리 중 중간 8자리를 *로 마스킹하여 보안을 강화했습니다. (예: 1234-****-****-5678)

주민등록번호 마스킹: 주민등록번호 뒷자리 7자리 중 6자리를 *로 마스킹 처리했습니다. (예: 950101-1******)